### PR TITLE
Player move refactor

### DIFF
--- a/public/src/move.js
+++ b/public/src/move.js
@@ -1,0 +1,56 @@
+(function(exports) {
+  function Move() {
+  }
+    Move.prototype.moveRD = function(myPlayer, collisionObject, rightUp, xy) {
+      playerCoord = getCoord(myPlayer, xy);
+      canvasDimension = getDimension(myPlayer, xy)['canvasDimension'];
+      spriteDimension = getDimension(myPlayer, xy)['spriteDimension'];
+
+      if (playerCoord + myPlayer._moveDelta > canvasDimension - spriteDimension) {
+        return canvasDimension - spriteDimension;
+      } else if (collisionObject['collide'] === true) {
+        dialogueBoxProject.show(collisionObject['object'])
+        return (getCoord(collisionObject['object'], xy) - spriteDimension);
+      } else {
+        game.consumeAP()
+        return playerCoord + myPlayer._moveDelta;
+      };
+    };
+
+    Move.prototype.moveLU = function(myPlayer, collisionObject, leftDown, xy) {
+      playerCoord = getCoord(myPlayer, xy);
+
+      if (playerCoord - myPlayer._moveDelta < 0) {
+        return 0;
+      } else if (collisionObject['collide'] === true) {
+        dialogueBoxProject.show(collisionObject['object'])
+        return (getCoord(collisionObject['object'], xy) + getDimension(collisionObject['object'], xy)['spriteDimension'])
+      } else {
+        game.consumeAP()
+        return playerCoord - myPlayer._moveDelta;
+      };
+    };
+
+    getCoord = function(object, xy) {
+      if (xy === "x") {
+        return object._x;
+      } else if (xy === "y") {
+        return object._y;
+      }
+    }
+
+    getDimension = function(object, xy) {
+      if (xy === "x") {
+        return dimHash = {
+          'canvasDimension': object._canvas.width,
+          'spriteDimension': object._spriteWidth
+        }
+      } else if (xy === "y") {
+        return dimHash = {
+          'canvasDimension': object._canvas.height,
+          'spriteDimension': object._spriteHeight
+        }
+      }
+    }
+  exports.Move = Move
+})(this);

--- a/public/src/npc.js
+++ b/public/src/npc.js
@@ -23,9 +23,7 @@
     this._ctx.beginPath();
     this._ctx.drawImage(this._sprite, this._sprite_x, this._sprite_y, this._sprite_w,
                         this._sprite_h, this._x, this._y, this._sprite_w, this._sprite_h);
-
     this._ctx.fill();
-
     this._ctx.closePath();
   }
 

--- a/public/src/player.js
+++ b/public/src/player.js
@@ -52,68 +52,15 @@ Player.prototype.reposition = function(myPlayer) {
 
   if (myPlayer._rightPressed) {
     var object = collisionLogic.collision(myPlayer, myPlayer._collisionable, myPlayer._moveDelta, 'R');
-    myPlayer._x = myPlayer.moveRD(myPlayer, object, "R", "x");
+    myPlayer._x = move.moveRD(myPlayer, object, "R", "x");
   } else if (myPlayer._downPressed) {
     var object = collisionLogic.collision(myPlayer, myPlayer._collisionable, myPlayer._moveDelta, 'D');
-    myPlayer._y = myPlayer.moveRD(myPlayer, object, "D", "y");
+    myPlayer._y = move.moveRD(myPlayer, object, "D", "y");
   } else if (myPlayer._upPressed) {
     var object = collisionLogic.collision(myPlayer, myPlayer._collisionable, myPlayer._moveDelta, 'U');
-    myPlayer._y = myPlayer.moveLU(myPlayer, object, "U", "y");
+    myPlayer._y = move.moveLU(myPlayer, object, "U", "y");
   } else if (myPlayer._leftPressed) {
     var object = collisionLogic.collision(myPlayer, myPlayer._collisionable, myPlayer._moveDelta, 'L');
-    myPlayer._x = myPlayer.moveLU(myPlayer, object, "L", "x");
+    myPlayer._x = move.moveLU(myPlayer, object, "L", "x");
   };
 };
-
-Player.prototype.moveRD = function(myPlayer, collisionObject, rightUp, xy) {
-  playerCoord = getCoord(myPlayer, xy);
-  canvasDimension = getDimension(myPlayer, xy)['canvasDimension'];
-  spriteDimension = getDimension(myPlayer, xy)['spriteDimension'];
-
-  if (playerCoord + myPlayer._moveDelta > canvasDimension - spriteDimension) {
-    return canvasDimension - spriteDimension;
-  } else if (collisionObject['collide'] === true) {
-    dialogueBoxProject.show(collisionObject['object'])
-    return (getCoord(collisionObject['object'], xy) - spriteDimension);
-  } else {
-    game.consumeAP()
-    return playerCoord + myPlayer._moveDelta;
-  };
-};
-
-Player.prototype.moveLU = function(myPlayer, collisionObject, leftDown, xy) {
-  playerCoord = getCoord(myPlayer, xy);
-
-  if (playerCoord - myPlayer._moveDelta < 0) {
-    return 0;
-  } else if (collisionObject['collide'] === true) {
-    dialogueBoxProject.show(collisionObject['object'])
-    return (getCoord(collisionObject['object'], xy) + getDimension(collisionObject['object'], xy)['spriteDimension'])
-  } else {
-    game.consumeAP()
-    return playerCoord - myPlayer._moveDelta;
-  };
-};
-
-getCoord = function(object, xy) {
-  if (xy === "x") {
-    return object._x;
-  } else if (xy === "y") {
-    return object._y;
-  }
-}
-
-getDimension = function(object, xy) {
-  if (xy === "x") {
-    dimHash = {
-      'canvasDimension': object._canvas.width,
-      'spriteDimension': object._spriteWidth
-    }
-  } else if (xy === "y") {
-    dimHash = {
-      'canvasDimension': object._canvas.height,
-      'spriteDimension': object._spriteHeight
-    }
-  }
-  return dimHash;
-}

--- a/public/src/player.js
+++ b/public/src/player.js
@@ -117,27 +117,3 @@ getDimension = function(object, xy) {
   }
   return dimHash;
 }
-
-// Player.prototype.moveLeft = function(myPlayer, collisionObject) {
-//   if (myPlayer._x - myPlayer._moveDelta < 0) {
-//     myPlayer._x = 0;
-//   } else if (collisionObject['collide'] === true) {
-//     myPlayer._x = (collisionObject['object']._x + collisionObject['object']._spriteWidth)
-//     dialogueBoxProject.show(collisionObject['object'])
-//   } else {
-//     myPlayer._x -= myPlayer._moveDelta;
-//     game.consumeAP()
-//   };
-// };
-//
-// Player.prototype.moveUp = function(myPlayer, collisionObject) {
-//   if (myPlayer._y - myPlayer._moveDelta < 0) {
-//     myPlayer._y = 0;
-//   } else if (collisionObject['collide'] === true) {
-//     myPlayer._y = (collisionObject['object']._y + collisionObject['object']._spriteHeight)
-//     dialogueBoxProject.show(collisionObject['object'])
-//   } else {
-//     myPlayer._y -= myPlayer._moveDelta;
-//     game.consumeAP()
-//   };
-// };

--- a/public/src/player.js
+++ b/public/src/player.js
@@ -14,7 +14,7 @@ function Player(game) {
   this._frameCount = 3;
 
   this._x = (this._canvas.width - this._spriteWidth) / 2;
-  this._y = (this._canvas.height - this._spriteHeight)/2;
+  this._y = (this._canvas.height - this._spriteHeight) / 2;
   this._moveDelta = 10;
   this._collisionable = [];
 
@@ -52,63 +52,92 @@ Player.prototype.reposition = function(myPlayer) {
 
   if (myPlayer._rightPressed) {
     var object = collisionLogic.collision(myPlayer, myPlayer._collisionable, myPlayer._moveDelta, 'R');
-    myPlayer.moveRight(myPlayer, object);
-  } else if (myPlayer._leftPressed) {
-    var object = collisionLogic.collision(myPlayer, myPlayer._collisionable, myPlayer._moveDelta, 'L');
-    myPlayer.moveLeft(myPlayer, object);
+    myPlayer._x = myPlayer.moveRD(myPlayer, object, "R", "x");
   } else if (myPlayer._downPressed) {
     var object = collisionLogic.collision(myPlayer, myPlayer._collisionable, myPlayer._moveDelta, 'D');
-    myPlayer.moveDown(myPlayer, object);
+    myPlayer._y = myPlayer.moveRD(myPlayer, object, "D", "y");
   } else if (myPlayer._upPressed) {
     var object = collisionLogic.collision(myPlayer, myPlayer._collisionable, myPlayer._moveDelta, 'U');
-    myPlayer.moveUp(myPlayer, object);
+    myPlayer._y = myPlayer.moveLU(myPlayer, object, "U", "y");
+  } else if (myPlayer._leftPressed) {
+    var object = collisionLogic.collision(myPlayer, myPlayer._collisionable, myPlayer._moveDelta, 'L');
+    myPlayer._x = myPlayer.moveLU(myPlayer, object, "L", "x");
   };
 };
 
-Player.prototype.moveRight = function(myPlayer, collisionObject) {
-  if (myPlayer._x + myPlayer._moveDelta > myPlayer._canvas.width - myPlayer._spriteWidth) {
-    myPlayer._x = myPlayer._canvas.width - myPlayer._spriteWidth;
+Player.prototype.moveRD = function(myPlayer, collisionObject, rightUp, xy) {
+  playerCoord = getCoord(myPlayer, xy);
+  canvasDimension = getDimension(myPlayer, xy)['canvasDimension'];
+  spriteDimension = getDimension(myPlayer, xy)['spriteDimension'];
+
+  if (playerCoord + myPlayer._moveDelta > canvasDimension - spriteDimension) {
+    return canvasDimension - spriteDimension;
   } else if (collisionObject['collide'] === true) {
-    myPlayer._x = (collisionObject['object']._x - myPlayer._spriteWidth);
     dialogueBoxProject.show(collisionObject['object'])
+    return (getCoord(collisionObject['object'], xy) - spriteDimension);
   } else {
-    myPlayer._x += myPlayer._moveDelta;
     game.consumeAP()
+    return playerCoord + myPlayer._moveDelta;
   };
 };
 
-Player.prototype.moveLeft = function(myPlayer, collisionObject) {
-  if (myPlayer._x - myPlayer._moveDelta < 0) {
-    myPlayer._x = 0;
+Player.prototype.moveLU = function(myPlayer, collisionObject, leftDown, xy) {
+  playerCoord = getCoord(myPlayer, xy);
+
+  if (playerCoord - myPlayer._moveDelta < 0) {
+    return 0;
   } else if (collisionObject['collide'] === true) {
-    myPlayer._x = (collisionObject['object']._x + collisionObject['object']._spriteWidth)
     dialogueBoxProject.show(collisionObject['object'])
+    return (getCoord(collisionObject['object'], xy) + getDimension(collisionObject['object'], xy)['spriteDimension'])
   } else {
-    myPlayer._x -= myPlayer._moveDelta;
     game.consumeAP()
+    return playerCoord - myPlayer._moveDelta;
   };
 };
 
-Player.prototype.moveDown = function(myPlayer, collisionObject) {
-  if (myPlayer._y + myPlayer._moveDelta > myPlayer._canvas.height - myPlayer._spriteHeight) {
-    myPlayer._y = myPlayer._canvas.height - myPlayer._spriteHeight;
-  } else if (collisionObject['collide'] === true) {
-    myPlayer._y = (collisionObject['object']._y - myPlayer._spriteHeight)
-    dialogueBoxProject.show(collisionObject['object'])
-  } else {
-    myPlayer._y += myPlayer._moveDelta;
-    game.consumeAP()
-  };
-};
+getCoord = function(object, xy) {
+  if (xy === "x") {
+    return object._x;
+  } else if (xy === "y") {
+    return object._y;
+  }
+}
 
-Player.prototype.moveUp = function(myPlayer, collisionObject) {
-  if (myPlayer._y - myPlayer._moveDelta < 0) {
-    myPlayer._y = 0;
-  } else if (collisionObject['collide'] === true) {
-    myPlayer._y = (collisionObject['object']._y + collisionObject['object']._spriteHeight)
-    dialogueBoxProject.show(collisionObject['object'])
-  } else {
-    myPlayer._y -= myPlayer._moveDelta;
-    game.consumeAP()
-  };
-};
+getDimension = function(object, xy) {
+  if (xy === "x") {
+    dimHash = {
+      'canvasDimension': object._canvas.width,
+      'spriteDimension': object._spriteWidth
+    }
+  } else if (xy === "y") {
+    dimHash = {
+      'canvasDimension': object._canvas.height,
+      'spriteDimension': object._spriteHeight
+    }
+  }
+  return dimHash;
+}
+
+// Player.prototype.moveLeft = function(myPlayer, collisionObject) {
+//   if (myPlayer._x - myPlayer._moveDelta < 0) {
+//     myPlayer._x = 0;
+//   } else if (collisionObject['collide'] === true) {
+//     myPlayer._x = (collisionObject['object']._x + collisionObject['object']._spriteWidth)
+//     dialogueBoxProject.show(collisionObject['object'])
+//   } else {
+//     myPlayer._x -= myPlayer._moveDelta;
+//     game.consumeAP()
+//   };
+// };
+//
+// Player.prototype.moveUp = function(myPlayer, collisionObject) {
+//   if (myPlayer._y - myPlayer._moveDelta < 0) {
+//     myPlayer._y = 0;
+//   } else if (collisionObject['collide'] === true) {
+//     myPlayer._y = (collisionObject['object']._y + collisionObject['object']._spriteHeight)
+//     dialogueBoxProject.show(collisionObject['object'])
+//   } else {
+//     myPlayer._y -= myPlayer._moveDelta;
+//     game.consumeAP()
+//   };
+// };

--- a/public/src/render.js
+++ b/public/src/render.js
@@ -22,6 +22,7 @@ $(document).ready(function() {
     npc_computer6 = new Npc('computer', 455, 450, 50, 110, script, game, sprite_computer)
     npc_computer7 = new Npc('computer', 455, 160, 50, 175, script, game, sprite_computer)
     npc_computer8 = new Npc('computer', 455, 670, 50, 50, script, game, sprite_computer)
+    npc_computer9 = new Npc('computer', 550, 670, 50, 50, script, game, sprite_computer)
 
     sprite_lana = {
       src: '../img/npc_f.png',
@@ -30,7 +31,7 @@ $(document).ready(function() {
       w: 32,
       h: 45
     }
-    npc_lana = new Npc('lana', 500, 50, 32, 45, script, game, sprite_lana);
+    npc_lana = new Npc('lana', 510, 51, 32, 45, script, game, sprite_lana);
 
     sprite_ned = {
       src: '../img/npc_m.png',
@@ -61,9 +62,7 @@ $(document).ready(function() {
 
     player._collisionable.push(npc_lana, npc_ned, collisionBox10, collisionBox11,
       collisionBox12, collisionBox13, collisionBox14, collisionBox15, collisionBox16, npc_computer1, npc_computer2,
-      npc_computer3, npc_computer4, npc_computer5, npc_computer6, npc_computer7, npc_computer8
-
-    )
+      npc_computer3, npc_computer4, npc_computer5, npc_computer6, npc_computer7, npc_computer8, npc_computer9)
 
     setInterval(function() {
       game.draw([player, npc_lana, npc_ned,
@@ -71,7 +70,7 @@ $(document).ready(function() {
         collisionBox12, collisionBox13, collisionBox14, collisionBox15, collisionBox16,
         dialogueBoxProject, actionPointsBar, energyPointsBar, projectPointsBar, cycle,
         npc_computer1, npc_computer2, npc_computer3, npc_computer4, npc_computer5,
-        npc_computer6, npc_computer7, npc_computer8
+        npc_computer6, npc_computer7, npc_computer8, npc_computer9
       ])
     }, 100);
   });
@@ -122,8 +121,7 @@ $(document).ready(function() {
         if (dialogueBoxProject.exhausted === true) {
           dialogueBoxProject.hide();
           dialogueBoxProject.exhausted = false;
-        }
-        else if (dialogueBoxProject._inUse === true && dialogueBoxProject.finalDialogue() !== true) {
+        } else if (dialogueBoxProject._inUse === true && dialogueBoxProject.finalDialogue() !== true) {
           dialogueBoxProject._count += 1
         }
       }

--- a/public/src/render.js
+++ b/public/src/render.js
@@ -5,6 +5,7 @@ $(document).ready(function() {
     player = new Player(game);
     collisionLogic = new CollisionLogic();
     script = new Script();
+    move = new Move();
 
     sprite_computer = {
       src: '',

--- a/public/testrunner.html
+++ b/public/testrunner.html
@@ -31,6 +31,7 @@
   <script src="src/game.js"></script>
   <script src="src/cycle.js"></script>
   <script src="src/wrapCanvasText.js"></script>
+  <script src="src/move.js"></script>
 
 
 

--- a/public/views/game.html
+++ b/public/views/game.html
@@ -21,6 +21,7 @@
    <script src="src/projectScore.js"></script>
    <script src="src/cycle.js"></script>
    <script src="src/game.js"></script>
+   <script src="src/move.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Moved all "movement" related functions to its own constructor (move.js).
It's hard to explain in writing but I've managed to implement the DRY principle so that we don't have 4 rather similar looking functions determine Ada's position.
I managed to use a generic function them because Right and Down had near identical functions but one altered x and the other y. Similarly for Left and Down.
I use two helper functions to determine other necessary attributes.
The value is then returned and is set within the Player class.
I've only user tested this. All unit tests involving movement are now broken but will resolve later.